### PR TITLE
Feat/apple login

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -71,6 +71,7 @@ export default ({ config }) => ({
         },
       },
     ],
+    "expo-apple-authentication",
   ],
   experiments: {
     typedRoutes: true,

--- a/components/login/AppleLogin.tsx
+++ b/components/login/AppleLogin.tsx
@@ -1,0 +1,24 @@
+import { Image } from "expo-image";
+import { Platform, Pressable, Text } from "react-native";
+
+import { IOSAppleLogin, AndroidAppleLogin } from "@/features/auth/appleLogin";
+
+export default function AppleLogin() {
+  const handlePress =
+    Platform.OS === "android" ? AndroidAppleLogin : IOSAppleLogin;
+  return (
+    <Pressable
+      onPress={handlePress}
+      className="flex-row items-center justify-center gap-2 rounded-xl bg-black px-6 py-4 active:opacity-80"
+    >
+      <Image
+        source={require("@/assets/images/login/apple_logo.png")}
+        contentFit="contain"
+        style={{ width: 24, height: 24 }}
+      />
+      <Text className="text-base font-semibold text-white">
+        Apple 계정으로 로그인하기
+      </Text>
+    </Pressable>
+  );
+}

--- a/components/login/SocialLoginButtons.tsx
+++ b/components/login/SocialLoginButtons.tsx
@@ -1,44 +1,14 @@
-import * as AppleAuthentication from "expo-apple-authentication";
-import { Image } from "expo-image";
 import { router } from "expo-router";
 import { Pressable, Text, View } from "react-native";
 
+import AppleLogin from "@/components/login/AppleLogin";
 import KakaoLogin from "@/components/login/KakaoLogin";
 
 export default function SocialLoginButtons() {
   return (
     <View className="w-full gap-3 bg-white py-20">
-      <Pressable
-        onPress={async () => {
-          try {
-            const credential = await AppleAuthentication.signInAsync({
-              requestedScopes: [
-                AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
-                AppleAuthentication.AppleAuthenticationScope.EMAIL,
-              ],
-            });
-            console.log("credential", credential);
-          } catch (error: any) {
-            if (error.code === "ERR_REQUEST_CANCELED") {
-              console.log("user canceled the sign - in flow");
-            } else {
-              console.log(error);
-            }
-          }
-        }}
-        className="flex-row items-center justify-center gap-2 rounded-xl bg-black px-6 py-4 active:opacity-80"
-      >
-        <Image
-          source={require("@/assets/images/login/apple_logo.png")} // 이미지 교체 예정
-          contentFit="contain"
-          style={{ width: 24, height: 24 }}
-        />
-        <Text className="text-base font-semibold text-white">
-          Apple 계정으로 로그인하기(IOS)
-        </Text>
-      </Pressable>
+      <AppleLogin />
       <KakaoLogin />
-
       <Pressable
         onPress={() => router.push("/(tabs)")}
         className="mt-4 flex-row items-center justify-center"

--- a/components/login/SocialLoginButtons.tsx
+++ b/components/login/SocialLoginButtons.tsx
@@ -1,3 +1,4 @@
+import * as AppleAuthentication from "expo-apple-authentication";
 import { Image } from "expo-image";
 import { router } from "expo-router";
 import { Pressable, Text, View } from "react-native";
@@ -8,7 +9,23 @@ export default function SocialLoginButtons() {
   return (
     <View className="w-full gap-3 bg-white py-20">
       <Pressable
-        onPress={() => router.push("/login/apple")}
+        onPress={async () => {
+          try {
+            const credential = await AppleAuthentication.signInAsync({
+              requestedScopes: [
+                AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+                AppleAuthentication.AppleAuthenticationScope.EMAIL,
+              ],
+            });
+            console.log("credential", credential);
+          } catch (error: any) {
+            if (error.code === "ERR_REQUEST_CANCELED") {
+              console.log("user canceled the sign - in flow");
+            } else {
+              console.log(error);
+            }
+          }
+        }}
         className="flex-row items-center justify-center gap-2 rounded-xl bg-black px-6 py-4 active:opacity-80"
       >
         <Image
@@ -17,7 +34,7 @@ export default function SocialLoginButtons() {
           style={{ width: 24, height: 24 }}
         />
         <Text className="text-base font-semibold text-white">
-          Apple 계정으로 로그인하기(미완)
+          Apple 계정으로 로그인하기(IOS)
         </Text>
       </Pressable>
       <KakaoLogin />

--- a/features/auth/appleLogin.ts
+++ b/features/auth/appleLogin.ts
@@ -1,0 +1,20 @@
+import * as AppleAuthentication from "expo-apple-authentication";
+
+export async function IOSAppleLogin() {
+  try {
+    const credential = await AppleAuthentication.signInAsync({
+      requestedScopes: [
+        AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+        AppleAuthentication.AppleAuthenticationScope.EMAIL,
+      ],
+    });
+    console.log("credential", credential);
+    // TODO : 로그인 로직 반영
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+export async function AndroidAppleLogin() {
+  console.log("Android Login");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/native": "^7.1.6",
         "@use-funnel/react-navigation-native": "^0.0.15",
         "expo": "~53.0.10",
+        "expo-apple-authentication": "~7.2.4",
         "expo-blur": "~14.1.5",
         "expo-build-properties": "~0.14.6",
         "expo-constants": "~17.1.6",
@@ -8266,6 +8267,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-7.2.4.tgz",
+      "integrity": "sha512-T2agaLLPT4Ax97FeXImB7BCCEzEJ0gB+ZwlFa/FXBtbp6WFKcGRlTVKiX2YPYLZzN5QjXcmQ9HHJ17jRthNHMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-asset": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react-native-webview": "13.13.5",
     "tailwindcss": "^3.4.17",
     "zustand": "^5.0.5",
-    "react-native-svg": "15.11.2"
+    "react-native-svg": "15.11.2",
+    "expo-apple-authentication": "~7.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Related task
- 애플 로그인 기능 구현, os에 따른 로그인 로직 분리

## Result

https://github.com/user-attachments/assets/f80039b6-43d5-4f97-b16c-ea52985a7f95

<img width="1386" alt="스크린샷 2025-06-24 오후 2 39 20" src="https://github.com/user-attachments/assets/ab62f95f-9991-46b6-80e5-10b3c5718b35" />

로그인 이후 정보 받아오는 것 까지 확인했습니다.

## Work list
- AppleLogin 컴포넌트 구성 및 Android/IOS로직분리

## Discussion
- 카카오 로그인 안드로이드 가상머신으로 로그인 확인해보고있는데, 인터넷 연결이 동작하지 않아서 공기계로 확인해봐야할거같아요. 웹뷰로 로그인 창 띄우는데, 이게 불가능해서 확인이 어렵네요.